### PR TITLE
Update to the sha on main for taker-py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ certifi==2023.5.7
 charset-normalizer==3.1.0
 click==8.1.3
 frozenlist==1.3.3
-git+ssh://git@github.com/hashflownetwork/taker-py@f4b3f99d1b0c3e704f16ff57aa5ccb8b0dbd9616#egg-hashflow
+git+ssh://git@github.com/hashflownetwork/taker-py@17ac9686db2b8647a3148d9f7b55e9c0d7746adb#egg-hashflow
 idna==3.4
 multidict==6.0.4
 mypy-extensions==1.0.0


### PR DESCRIPTION
Turns out the sha for `taker-py` changed when the branch was pushed to main, so we have to update the sha.