### PR TITLE
Pull hashflow-taker-sdk from PyPI.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ certifi==2023.5.7
 charset-normalizer==3.1.0
 click==8.1.3
 frozenlist==1.3.3
-git+ssh://git@github.com/hashflownetwork/taker-py@17ac9686db2b8647a3148d9f7b55e9c0d7746adb#egg-hashflow
+hashflow-taker-sdk==1.0.0
 idna==3.4
 multidict==6.0.4
 mypy-extensions==1.0.0


### PR DESCRIPTION
Instead of pulling from a GitHub repo, we pull from the published package index.

Test Plan:
- pip install -r ..
- ran QA for one maker on Ethereum